### PR TITLE
Key listener method register

### DIFF
--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import functools
 import logging
 from pathlib import Path
 import threading
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, NamedTuple, Optional, Type
+from weakref import WeakSet
 
 import pygame
 
@@ -106,9 +108,40 @@ class KeyListener:
     _listeners: dict[str, KeyListener] = {}
 
     def __init__(self, handle: str) -> None:
-        self.key_map: KeyMap = KeyMap()
-        self._key_hooks: dict[str, dict[int, list[Callable]]] = {}
         self.handle: str = handle
+        self.key_map: KeyMap = KeyMap()
+
+        # Workflow:
+        # Key event -> send key to key map
+        # Key map -> bind name, mod keys
+        # Check mod keys, bind name -> dict w/ event types
+        # Feed event type -> get callable
+        # Call the callable
+
+        # --------Basic function assignment--------
+        # Meta dict, string bind name as key, then event type as key to get callable
+        self._key_hooks: dict[str, dict[int, list[Callable]]] = {}
+
+        # Workflow:
+        # Key event -> send key to key map
+        # Key map -> bind name, mod keys
+        # Check mod keys, bind name -> dict w/ event types
+        # Feed event type -> get callable
+        # Call the callable
+
+        # --------Class method assignment--------
+        # Meta dict, string bind name as key, then Pygame event key, method and
+        # affected object as values
+        self._class_listeners: dict[
+            str, dict[int, list[tuple[Callable, Type[object]]]]
+        ] = {}
+        # Registered object as key, instances of object as values
+        # Instances are unique, so make it a set for weak reference
+        self._class_listener_instances: dict[Type[object], WeakSet[object]] = {}
+        # Inversion of _class_listeners. Method as key, event id as values
+        self._class_listener_events: dict[Callable, list[int]] = {}
+        # Assigned object as key, associated methods as values
+        self._assigned_classes: dict[Type[object], list[Callable]] = {}
 
     def bind(
         self,
@@ -150,7 +183,7 @@ class KeyListener:
     def rebind(
         self,
         key_bind_name: str,
-        new_key: Optional[int],
+        new_key: int | None,
         new_mod: Optional[int] = None,
     ) -> tuple[int | None, int] | None:
         """
@@ -214,6 +247,150 @@ class KeyListener:
                     )
                     bind.remove(func)
 
+    def register_class(self, cls: Type[object]) -> Type[object]:
+        """
+        Prepares a class for event handling.
+        This will hijack the class's init method to push its instances into
+        the assigned key listener.
+
+        It will also go through and clean up the assigned methods.
+        """
+        cls.__init__ = self._modify_init(cls.__init__)  # type: ignore
+        # Add all of the tagged methods to the callables list
+        logger.debug("Checking for marked methods")
+        for _, method in cls.__dict__.items():
+            if not hasattr(method, "_assigned_listeners"):
+                continue
+
+            logger.debug("Found marked method")
+
+            _assigned_listeners: list[
+                tuple[KeyListener, str, int | None, int | None, int]
+            ] = getattr(method, "_assigned_listeners", [])
+
+            self._verify_listener(cls, method, _assigned_listeners)
+
+            if len(_assigned_listeners) == 0:
+                delattr(method, "_assigned_listeners")
+
+        return cls
+
+    def _verify_listener(
+        self,
+        cls: Type[object],
+        method: Callable,
+        listeners: list[tuple[KeyListener, str, int | None, int | None, int]],
+    ) -> None:
+        """
+        Checks the list of assigned managers for a method and captures it if it is
+        assigned to the calling manager
+
+        :param cls: Class of the object being processed
+        :param method: Callable being registered
+        :param managers: list of managers and pygame events being processed.
+        """
+        _indexes_to_remove: list[int] = []
+        for index, (
+            listener,
+            bind_name,
+            default_key,
+            default_mod,
+            event_type,
+        ) in enumerate(listeners):
+            logger.debug(f"Found assigned manager: {listener}")
+            if listener is not self:
+                continue
+            self._capture_method(
+                cls, method, bind_name, default_key, default_mod, event_type
+            )
+            _indexes_to_remove.append(index)
+            break
+        for index in reversed(_indexes_to_remove):
+            listeners.pop(index)
+
+    def _capture_method(
+        self,
+        cls: Type[object],
+        method: Callable,
+        key_bind_name: str,
+        default_key: int | None,
+        default_mod: int | None,
+        event_type: int,
+    ) -> None:
+        """
+        Adds the method, class, and event into the appropriate dictionaries to ensure
+        they can be properly notified.
+
+        :param cls: Class of the object being processed
+        :param method: Callable being registered
+        :param managers: list of managers and pygame events being processed.
+        """
+        logger.debug("Found method assigned to self. Registering.")
+        logger.debug(f"Registering {method} to {pygame.event.event_name(event_type)}")
+
+        self._generate_bind(key_bind_name, default_key, default_mod)
+
+        self._class_listeners.setdefault(key_bind_name, {}).setdefault(
+            event_type, []
+        ).append((method, cls))
+        self._class_listener_events.setdefault(method, []).append(event_type)
+        self._assigned_classes.setdefault(cls, []).append(method)
+
+    def _modify_init(self, init: Callable) -> Callable:
+        """
+        Extracts the class and instance being generated, and puts them into a
+        dict, so that the method can be called upon it
+
+        :param init: The initializer function of a class being registered.
+        :return: The modified init function
+        """
+        functools.wraps(init)  # Needs this
+
+        def wrapper(*args, **kwds):
+            # args[0] of a non-class, non-static method is the instance
+            # This is called whenever the class is instantiated,
+            # and the instance is extracted and can be stored
+            instance = args[0]
+            cls = instance.__class__
+            # No need to check for the instance, each only calls this once
+            self._class_listener_instances.setdefault(cls, WeakSet()).add(instance)
+            logger.debug(f"Extracted instance {instance} from {cls}")
+            return init(*args, **kwds)
+
+        return wrapper
+
+    def bind_method(
+        self,
+        key_bind_name: str,
+        default_key: Optional[int] = None,
+        default_mod: Optional[int] = None,
+        event_type: int = pygame.KEYDOWN,
+    ) -> Callable:
+        """
+        Wrapper that marks the method for registration when the class is registered.
+
+        The method's class should be registered with all event managers that have
+        registered a method in that class. Failure to do so will leave a dangling
+        attribute on those methods.
+
+        :param event_type: Pygame event type that will call the assigned method.
+        """
+
+        def decorator(method: Callable) -> Callable:
+            # Nearly an exact duplicate of the EventManager version
+            assigned_listeners: list[
+                tuple[KeyListener, str, int | None, int | None, int]
+            ] = []
+            if hasattr(method, "_assigned_listeners"):
+                assigned_listeners = getattr(method, "_assigned_listeners", [])
+            assigned_listeners.append(
+                (self, key_bind_name, default_key, default_mod, event_type)
+            )
+            setattr(method, "_assigned_listeners", assigned_listeners)
+            return method
+
+        return decorator
+
     def clear_bind(self, bind_name: str, eliminate_bind: bool = False) -> None:
         """
         Clears all callables from the specified bind name
@@ -275,6 +452,13 @@ class KeyListener:
             for responder in responders:
                 threading.Thread(target=responder, args=(event,)).start()
                 # hook(event)
+
+            method_hooks = self._class_listeners.get(key_bind.bind_name, {})
+            listeners = method_hooks.get(event.type, [])
+            for method, cls in listeners:
+                instances = self._class_listener_instances.get(cls, WeakSet())
+                for instance in instances:
+                    threading.Thread(target=method, args=(instance, event)).start()
 
     def load_from_file(self, filepath: Path) -> None:
         raise NotImplementedError("This feature is not yet available")

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -408,10 +408,16 @@ class KeyListener:
             self.key_map.remove_bind(bind_name)
             return
         call_list = self._key_hooks.get(bind_name, None)
-        if call_list is None:
+        class_call_list = self._class_listeners.get(bind_name, None)
+        if call_list is None and class_call_list is None:
             logger.warning(f" Bind '{bind_name}' not in key registry.")
             return
-        call_list.clear()
+        if call_list:
+            logger.info(f"Clearing all functions from bind {bind_name}")
+            call_list.clear()
+        if class_call_list:
+            logger.info(f"Clearing all methods from bind {bind_name}")
+            class_call_list.clear()
 
     def _generate_bind(
         self,

--- a/tests/test_key_manager.py
+++ b/tests/test_key_manager.py
@@ -1,14 +1,19 @@
 import pathlib
 import sys
 import threading
-from typing import Callable, cast
+from typing import Callable, cast, Type
 import unittest
 
 import pygame
 
 sys.path.append(str(pathlib.Path.cwd()))
 
-from src.event_handler.key_manager import getKeyListener, KeyBind, KeyMap  # noqa: E402
+from src.event_handler.key_manager import (  # noqa: E402
+    getKeyListener,
+    KeyBind,
+    KeyMap,
+    KeyListener,
+)
 
 
 class TestKeyMap(unittest.TestCase):
@@ -85,11 +90,28 @@ class TestKeyMap(unittest.TestCase):
 
 class TestKeyListener(unittest.TestCase):
 
+    def assertHasAttr(self, obj, intendedAttr: str):
+        testBool = hasattr(obj, intendedAttr)
+
+        self.assertTrue(testBool, msg=f"{obj=} lacks an attribute, {intendedAttr=}")
+
+    def assertNotHasAttr(self, obj, intendedAttr: str):
+        testBool = hasattr(obj, intendedAttr)
+
+        self.assertFalse(
+            testBool, msg=f"{obj=} has unexpected attribute, {intendedAttr=}"
+        )
+
     def setUp(self) -> None:
         self.key_listener = getKeyListener("TestCase")
 
     def tearDown(self) -> None:
+        self.key_listener.key_map.key_binds.clear()
         self.key_listener._key_hooks.clear()
+        self.key_listener._assigned_classes.clear()
+        self.key_listener._class_listener_binds.clear()
+        self.key_listener._class_listeners.clear()
+        self.key_listener._class_listener_instances.clear()
 
     def test_bind(self) -> None:
 
@@ -198,7 +220,119 @@ class TestKeyListener(unittest.TestCase):
 
         self.assertIsNone(self.key_listener._key_hooks.get("test_bind0"))
 
-    def test_notify(self) -> None:
+    def test_bind_method(self) -> None:
+
+        class TestClass:
+            @self.key_listener.bind_method("test_bind")
+            def test_method(self, _):
+                pass
+
+        self.assertHasAttr(TestClass.test_method, "_assigned_listeners")
+        assigned_listener_sets: list[
+            tuple[KeyListener, str, int | None, int | None, int]
+        ] = getattr(TestClass.test_method, "_assigned_listeners")
+        assigned_listeners = [set[0] for set in assigned_listener_sets]
+        self.assertIn(self.key_listener, assigned_listeners)
+
+    def test_register_class(self) -> None:
+
+        @self.key_listener.register_class
+        class TestClass:
+            @self.key_listener.bind_method("test_bind")
+            def test_method(self, _):
+                pass
+
+        test_instance = TestClass()
+
+        # Verify attribute cleanup
+        self.assertNotHasAttr(TestClass.test_method, "_assigned_listeners")
+        # Verify class in assigned classes
+        self.assertIn(TestClass, self.key_listener._assigned_classes.keys())
+        # Verify method in listeners
+        self.assertIn(
+            TestClass.test_method, self.key_listener._class_listener_binds.keys()
+        )
+        self.assertIn(
+            test_instance,
+            cast(
+                list[TestClass],
+                self.key_listener._class_listener_instances.get(TestClass),
+            ),
+        )
+        bound_listeners: dict[int, list[tuple[Callable, Type[object]]]] = (
+            self.key_listener._class_listeners.get("test_bind", {})
+        )
+        self.assertTrue(bound_listeners)
+        listeners: list[tuple[Callable, Type[object]]] = bound_listeners.get(
+            pygame.KEYDOWN, []
+        )
+        self.assertTrue(listeners)
+        listener_pair = (TestClass.test_method, TestClass)
+        # Verify method/object pair are associated with the event
+        self.assertIn(listener_pair, listeners)
+
+    def test_unbind_method(self) -> None:
+
+        @self.key_listener.register_class
+        class TestClass:
+            @self.key_listener.bind_method("test_bind")
+            def test_method(self, _):
+                pass
+
+            @self.key_listener.bind_method("test_bind")
+            def test_method2(self, _):
+                pass
+
+        # Variable is for GC purposes
+        # Don't want to bother with turning gc off
+        test_instance = TestClass()  # noqa: F841
+
+        self.key_listener.unbind_method(TestClass.test_method)
+        self.assertNotIn(
+            TestClass.test_method, self.key_listener._class_listener_binds.keys()
+        )
+        bound_listeners: dict[int, list[tuple[Callable, Type[object]]]] = (
+            self.key_listener._class_listeners.get("test_bind", {})
+        )
+        self.assertTrue(bound_listeners)
+        listeners: list[tuple[Callable, Type[object]]] = bound_listeners.get(
+            pygame.KEYDOWN, []
+        )
+        self.assertTrue(listeners)
+        listener_pair = (TestClass.test_method, TestClass)
+        # Verify method/object pair are associated with the event
+        self.assertNotIn(listener_pair, listeners)
+
+    def test_deregister_class(self) -> None:
+
+        @self.key_listener.register_class
+        class TestClass:
+            @self.key_listener.bind_method("test_bind")
+            def test_method(self, _):
+                pass
+
+        # Variable is for GC purposes
+        # Don't want to bother with turning gc off
+        test_instance = TestClass()  # noqa: F841
+
+        self.key_listener.deregister_class(TestClass)
+        # Verify method removed from listeners
+        self.assertNotIn(
+            TestClass.test_method, self.key_listener._class_listener_binds.keys()
+        )
+        self.assertNotIn(TestClass, self.key_listener._class_listener_instances.keys())
+        bound_listeners: dict[int, list[tuple[Callable, Type[object]]]] = (
+            self.key_listener._class_listeners.get("test_bind", {})
+        )
+        self.assertTrue(bound_listeners)
+        listeners: list[tuple[Callable, Type[object]]] = bound_listeners.get(
+            pygame.KEYDOWN, []
+        )
+        listener_pair = (TestClass.test_method, TestClass)
+        # Verify method/object pair are associated with the event
+        self.assertNotIn(listener_pair, listeners)
+
+    def test_notify_simple(self) -> None:
 
         example_var = False
         lock = threading.Lock()
@@ -263,6 +397,50 @@ class TestKeyListener(unittest.TestCase):
             self.key_listener.notify(event)
         # True, despite Alt also being pressed
         self.assertTrue(example_var)
+
+    def test_notify_class(self) -> None:
+
+        lock = threading.Lock()
+
+        @self.key_listener.register_class
+        class TestClass:
+            """
+            Simple class for testing
+            """
+
+            def __init__(self):
+                self.test_var = False
+
+            @self.key_listener.bind_method("test_bind", pygame.K_0)
+            def test_method(self, _):
+                lock.acquire()
+                self.test_var = True
+                lock.release()
+
+        test_class_list: list[TestClass] = []
+
+        for i in range(3):
+            test_class_list.append(TestClass())
+
+        local_event = pygame.event.Event(
+            pygame.KEYDOWN, unicode="9", key=pygame.K_9, mod=pygame.KMOD_NONE
+        )
+        pygame.event.post(local_event)
+
+        for event in pygame.event.get():
+            self.key_listener.notify(event)
+        for item in test_class_list:
+            self.assertFalse(item.test_var)
+
+        local_event = pygame.event.Event(
+            pygame.KEYDOWN, unicode="0", key=pygame.K_0, mod=pygame.KMOD_NONE
+        )
+        pygame.event.post(local_event)
+
+        for event in pygame.event.get():
+            self.key_listener.notify(event)
+        for item in test_class_list:
+            self.assertTrue(item.test_var)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New feature:

Allows classes and their methods to be registered to a key listener, so that the key event is passed on to every instance of that object