### PR TITLE
11 no way to loadsave key binds

### DIFF
--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -11,16 +11,34 @@ class JSONParser(FileParser):
 
     @staticmethod
     def load(in_file: TextIO) -> KeyMap:
+        """
+        Converts the given JSON file into a KeyMap
+
+        :param in_file: Target file with the required data.
+        :return: Created KeyMap
+        """
         maps = json.load(in_file)
         return JSONParser.unpack_binds(maps)
 
     @staticmethod
     def save(key_map: KeyMap, out_file: TextIO) -> None:
+        """
+        Saves the KeyMap as a JSON string
+
+        :param key_map: KeyMap object being saved
+        :param out_file: File receiving the data
+        """
         maps = key_map.pack_binds()
         json.dump(maps, out_file)
 
     @staticmethod
     def unpack_binds(maps: dict) -> KeyMap:
+        """
+        Converts the JSON-styled dict into a dict compatible with a KeyMap
+
+        :param maps: JSON-style dictionary of keybinds
+        :return: Dictionary compatible with KeyMap
+        """
         unpacked_dict: dict[int | None, list[KeyBind]] = {}
         for key_name, bind_list in maps.items():
             key_code = None

--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -9,16 +9,18 @@ import pygame
 
 class JSONParser(FileParser):
 
-    def load(self, in_file: TextIO) -> KeyMap:
-        # with open(self.file_path, "r") as file:
+    @staticmethod
+    def load(in_file: TextIO) -> KeyMap:
         maps = json.load(in_file)
-        return self.unpack_binds(maps)
+        return JSONParser.unpack_binds(maps)
 
-    def save(self, key_map: KeyMap, out_file: TextIO) -> None:
+    @staticmethod
+    def save(key_map: KeyMap, out_file: TextIO) -> None:
         maps = key_map.pack_binds()
         json.dump(maps, out_file)
 
-    def unpack_binds(self, maps: dict) -> KeyMap:
+    @staticmethod
+    def unpack_binds(maps: dict) -> KeyMap:
         unpacked_dict: dict[int | None, list[KeyBind]] = {}
         for key_name, bind_list in maps.items():
             key_code = None

--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -1,4 +1,5 @@
 import json
+from typing import TextIO
 
 from .key_manager import FileParser
 from .key_map import KeyMap, KeyBind
@@ -11,18 +12,17 @@ class JSONParser(FileParser):
     def __init__(self, file_path, key_map=None):
         super().__init__(file_path, key_map)
 
-    def load(self) -> KeyMap:
-        with open(self.file_path, "r") as file:
-            maps = json.load(file)
-            self.key_map = self.unpack_binds(maps)
+    def load(self, in_file: TextIO) -> KeyMap:
+        # with open(self.file_path, "r") as file:
+        maps = json.load(in_file)
+        self.key_map = self.unpack_binds(maps)
         return self.key_map
 
-    def save(self) -> None:
+    def save(self, out_file: TextIO) -> None:
         if not self.key_map:
             raise ValueError("Cannot save key map; Parser has no key map.")
-        with open(self.file_path, "w") as file:
-            maps = self.key_map.pack_binds()
-            json.dump(maps, file)
+        maps = self.key_map.pack_binds()
+        json.dump(maps, out_file)
 
     def unpack_binds(self, maps: dict) -> KeyMap:
         unpacked_dict: dict[int | None, list[KeyBind]] = {}

--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -9,19 +9,13 @@ import pygame
 
 class JSONParser(FileParser):
 
-    def __init__(self, file_path, key_map=None):
-        super().__init__(file_path, key_map)
-
     def load(self, in_file: TextIO) -> KeyMap:
         # with open(self.file_path, "r") as file:
         maps = json.load(in_file)
-        self.key_map = self.unpack_binds(maps)
-        return self.key_map
+        return self.unpack_binds(maps)
 
-    def save(self, out_file: TextIO) -> None:
-        if not self.key_map:
-            raise ValueError("Cannot save key map; Parser has no key map.")
-        maps = self.key_map.pack_binds()
+    def save(self, key_map: KeyMap, out_file: TextIO) -> None:
+        maps = key_map.pack_binds()
         json.dump(maps, out_file)
 
     def unpack_binds(self, maps: dict) -> KeyMap:

--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -18,7 +18,9 @@ class JSONParser(FileParser):
         :return: Created KeyMap
         """
         maps = json.load(in_file)
-        return JSONParser.unpack_binds(maps)
+        key_map = KeyMap()
+        key_map.key_binds = JSONParser._unpack_binds(maps)
+        return key_map
 
     @staticmethod
     def save(key_map: KeyMap, out_file: TextIO) -> None:
@@ -32,7 +34,7 @@ class JSONParser(FileParser):
         json.dump(maps, out_file)
 
     @staticmethod
-    def unpack_binds(maps: dict) -> KeyMap:
+    def _unpack_binds(maps: dict) -> dict:
         """
         Converts the JSON-styled dict into a dict compatible with a KeyMap
 
@@ -46,6 +48,4 @@ class JSONParser(FileParser):
                 key_code = pygame.key.key_code(key_name)
             binds = [KeyBind(bind_name=bind[0], mod=bind[1]) for bind in bind_list]
             unpacked_dict.update({key_code: binds})
-        key_map = KeyMap()
-        key_map.key_binds = unpacked_dict
-        return key_map
+        return unpacked_dict

--- a/src/event_handler/file_parser.py
+++ b/src/event_handler/file_parser.py
@@ -1,0 +1,37 @@
+import json
+
+from .key_manager import FileParser
+from .key_map import KeyMap, KeyBind
+
+import pygame
+
+
+class JSONParser(FileParser):
+
+    def __init__(self, file_path, key_map=None):
+        super().__init__(file_path, key_map)
+
+    def load(self) -> KeyMap:
+        with open(self.file_path, "r") as file:
+            maps = json.load(file)
+            self.key_map = self.unpack_binds(maps)
+        return self.key_map
+
+    def save(self) -> None:
+        if not self.key_map:
+            raise ValueError("Cannot save key map; Parser has no key map.")
+        with open(self.file_path, "w") as file:
+            maps = self.key_map.pack_binds()
+            json.dump(maps, file)
+
+    def unpack_binds(self, maps: dict) -> KeyMap:
+        unpacked_dict: dict[int | None, list[KeyBind]] = {}
+        for key_name, bind_list in maps.items():
+            key_code = None
+            if key_name != "null":
+                key_code = pygame.key.key_code(key_name)
+            binds = [KeyBind(bind_name=bind[0], mod=bind[1]) for bind in bind_list]
+            unpacked_dict.update({key_code: binds})
+        key_map = KeyMap()
+        key_map.key_binds = unpacked_dict
+        return key_map

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -428,7 +428,7 @@ class KeyListener:
                     threading.Thread(target=method, args=(instance, event)).start()
 
     @classmethod
-    def load_from_file(cls, file_path: Path, parser: FileParser) -> None:
+    def load_from_file(cls, file_path: Path, parser: Type[FileParser]) -> None:
         with open(file_path, "r") as file:
             binds = parser.load(file)
             cls.key_map.merge(binds)
@@ -437,7 +437,7 @@ class KeyListener:
     # raise NotImplementedError("This feature is not yet available")
 
     @classmethod
-    def save_to_file(cls, file_path: Path, parser: FileParser) -> None:
+    def save_to_file(cls, file_path: Path, parser: Type[FileParser]) -> None:
         with open(file_path, "w") as file:
             parser.save(cls.key_map, file)
         # raise NotImplementedError("This feature is not yet available")

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -28,7 +28,7 @@ class FileParser(ABC):
 
     @staticmethod
     @abstractmethod
-    def unpack_binds(maps: dict) -> KeyMap: ...
+    def _unpack_binds(maps: dict) -> dict: ...
 
 
 class KeyListener:

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -18,14 +18,17 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 class FileParser(ABC):
 
+    @staticmethod
     @abstractmethod
-    def load(self, in_file: TextIO) -> KeyMap: ...
+    def load(in_file: TextIO) -> KeyMap: ...
 
+    @staticmethod
     @abstractmethod
-    def save(self, key_map: KeyMap, out_file: TextIO) -> None: ...
+    def save(key_map: KeyMap, out_file: TextIO) -> None: ...
 
+    @staticmethod
     @abstractmethod
-    def unpack_binds(self, maps: dict) -> KeyMap: ...
+    def unpack_binds(maps: dict) -> KeyMap: ...
 
 
 class KeyListener:

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -38,23 +38,9 @@ class KeyListener:
     def __init__(self, handle: str) -> None:
         self.handle: str = handle
 
-        # Workflow:
-        # Key event -> send key to key map
-        # Key map -> bind name, mod keys
-        # Check mod keys, bind name -> dict w/ event types
-        # Feed event type -> get callable
-        # Call the callable
-
         # --------Basic function assignment--------
         # Meta dict, string bind name as key, then event type as key to get callable
         self._key_hooks: dict[str, dict[int, list[Callable]]] = {}
-
-        # Workflow:
-        # Key event -> send key to key map
-        # Key map -> bind name, mod keys
-        # Check mod keys, bind name -> dict w/ event types
-        # Feed event type -> get callable
-        # Call the callable
 
         # --------Class method assignment--------
         # Meta dict, string bind name as key, then Pygame event key, method and
@@ -381,6 +367,11 @@ class KeyListener:
             class_call_list.clear()
 
     def notify(self, event: pygame.Event) -> None:
+        """
+        Calls all registered functions and methods that make use of the given event
+
+        :param event: pygame event to be passed to the callables
+        """
         key_changed: int | None = getattr(event, "key", None)
         mod_keys: int | None = getattr(event, "mod", None)
         key_binds = self.key_map.key_binds.get(key_changed, [])
@@ -407,18 +398,32 @@ class KeyListener:
 
     @classmethod
     def load_from_file(cls, file_path: Path, parser: Type[FileParser]) -> None:
+        """
+        Pulls the file from the file path, and uses the supplied parser to convert the
+        file into a KeyMap, which is merged with the current KeyMap.
+
+        Binds in the current KeyMap that don't exist in the loaded KeyMap do not change,
+        all others are updated to reflect the loaded binds
+
+        :param file_path: path to the file to be loaded
+        :param parser: Parser to be used to decode the file.
+        Use one that matches the data structure
+        """
         with open(file_path, "r") as file:
             binds = parser.load(file)
             cls.key_map.merge(binds)
 
-    # cls.key_map.key_binds.update(binds.key_binds)
-    # raise NotImplementedError("This feature is not yet available")
-
     @classmethod
     def save_to_file(cls, file_path: Path, parser: Type[FileParser]) -> None:
+        """
+        Saves the current KeyMap to a file in the requested location.
+        Expects the file name and extension to be included.
+
+        :param file_path: Path to the file being saved to
+        :param parser: Parser used to encode the file.
+        """
         with open(file_path, "w") as file:
             parser.save(cls.key_map, file)
-        # raise NotImplementedError("This feature is not yet available")
 
 
 def notifyKeyListeners(event: pygame.Event) -> None:
@@ -432,4 +437,10 @@ def notifyKeyListeners(event: pygame.Event) -> None:
 
 
 def getKeyListener(handle: str) -> KeyListener:
+    """
+    Supplies a Key Listener with the given handle. If one exists with that handle,
+    the existing Key Listener is given. Otherwise, a new one is created.
+
+    :param handle: String describing the KeyListener.
+    """
     return KeyListener._listeners.setdefault(handle, KeyListener(handle))

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -93,7 +93,7 @@ class KeyListener:
         mod keys to be pressed. If using multiple, use bitwise OR to combine, defaults
         to None
         """
-        self._generate_bind(key_bind_name, default_key, default_mod)
+        self.key_map.generate_bind(key_bind_name, default_key, default_mod)
 
         def decorator(responder: Callable) -> Callable:
             # Regardless, add the responder to the bind within our hook dict
@@ -255,7 +255,7 @@ class KeyListener:
         logger.debug("Found method assigned to self. Registering.")
         logger.debug(f"Registering {method} to {pygame.event.event_name(event_type)}")
 
-        self._generate_bind(key_bind_name, default_key, default_mod)
+        self.key_map.generate_bind(key_bind_name, default_key, default_mod)
 
         self._class_listeners.setdefault(key_bind_name, {}).setdefault(
             event_type, []
@@ -379,30 +379,6 @@ class KeyListener:
         if class_call_list:
             logger.info(f"Clearing all methods from bind {bind_name}")
             class_call_list.clear()
-
-    def _generate_bind(
-        self,
-        key_bind_name: str,
-        default_key: Optional[int] = None,
-        default_mod: Optional[int] = None,
-    ) -> None:
-        """
-        Looks for a bind matching the given name.
-        Creates the bind if it does not exist.
-        Does not overwrite the key of an existing bind.
-
-        :param key_bind_name: Name assigned to the bind.
-        :param default_key: Pygame key code assigned to a new bind,
-        defaults to None
-        :param default_mod: bitmask of pygame modkeys for a new bind,
-        defaults to pygame.KMOD_NONE
-        """
-        try:
-            self.key_map.get_bound_key(key_bind_name)
-        except ValueError:
-            self.key_map.key_binds.setdefault(default_key, []).append(
-                KeyBind(bind_name=key_bind_name, mod=default_mod)
-            )
 
     def notify(self, event: pygame.Event) -> None:
         key_changed: int | None = getattr(event, "key", None)

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -397,7 +397,9 @@ class KeyListener:
         :param default_mod: bitmask of pygame modkeys for a new bind,
         defaults to pygame.KMOD_NONE
         """
-        if not self.key_map.get_bound_key(key_bind_name):
+        try:
+            self.key_map.get_bound_key(key_bind_name)
+        except ValueError:
             self.key_map.key_binds.setdefault(default_key, []).append(
                 KeyBind(bind_name=key_bind_name, mod=default_mod)
             )

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -5,7 +5,7 @@ import functools
 import logging
 from pathlib import Path
 import threading
-from typing import Callable, Optional, Type
+from typing import Callable, Optional, TextIO, Type
 from weakref import WeakSet
 
 # import file_parser
@@ -24,10 +24,10 @@ class FileParser(ABC):
         self.key_map = key_map
 
     @abstractmethod
-    def load(self) -> KeyMap: ...
+    def load(self, in_file: TextIO) -> KeyMap: ...
 
     @abstractmethod
-    def save(self) -> None: ...
+    def save(self, out_file: TextIO) -> None: ...
 
     @abstractmethod
     def unpack_binds(self, maps: dict) -> KeyMap: ...
@@ -431,17 +431,18 @@ class KeyListener:
 
     @classmethod
     def load_from_file(cls, parser: FileParser) -> None:
-        binds = parser.load()
-        for key, bind_list in binds.key_binds.items():
-            for bind in bind_list:
-                cls.key_map.rebind(bind, key)
-        # cls.key_map.key_binds.update(binds.key_binds)
-        # raise NotImplementedError("This feature is not yet available")
+        with open(parser.file_path, "r") as file:
+            binds = parser.load(file)
+            cls.key_map.merge(binds)
+
+    # cls.key_map.key_binds.update(binds.key_binds)
+    # raise NotImplementedError("This feature is not yet available")
 
     @classmethod
     def save_to_file(cls, parser: FileParser) -> None:
         parser.key_map = cls.key_map
-        parser.save()
+        with open(parser.file_path, "w") as file:
+            parser.save(file)
         # raise NotImplementedError("This feature is not yet available")
 
 

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -18,16 +18,11 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 class FileParser(ABC):
 
-    def __init__(self, file_path: Path, key_map: Optional[KeyMap] = None):
-        super().__init__()
-        self.file_path = file_path
-        self.key_map = key_map
-
     @abstractmethod
     def load(self, in_file: TextIO) -> KeyMap: ...
 
     @abstractmethod
-    def save(self, out_file: TextIO) -> None: ...
+    def save(self, key_map: KeyMap, out_file: TextIO) -> None: ...
 
     @abstractmethod
     def unpack_binds(self, maps: dict) -> KeyMap: ...
@@ -430,8 +425,8 @@ class KeyListener:
                     threading.Thread(target=method, args=(instance, event)).start()
 
     @classmethod
-    def load_from_file(cls, parser: FileParser) -> None:
-        with open(parser.file_path, "r") as file:
+    def load_from_file(cls, file_path: Path, parser: FileParser) -> None:
+        with open(file_path, "r") as file:
             binds = parser.load(file)
             cls.key_map.merge(binds)
 
@@ -439,10 +434,9 @@ class KeyListener:
     # raise NotImplementedError("This feature is not yet available")
 
     @classmethod
-    def save_to_file(cls, parser: FileParser) -> None:
-        parser.key_map = cls.key_map
-        with open(parser.file_path, "w") as file:
-            parser.save(file)
+    def save_to_file(cls, file_path: Path, parser: FileParser) -> None:
+        with open(file_path, "w") as file:
+            parser.save(cls.key_map, file)
         # raise NotImplementedError("This feature is not yet available")
 
 

--- a/src/event_handler/key_map.py
+++ b/src/event_handler/key_map.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass, field
+import logging
+from typing import NamedTuple, Optional
+
+import pygame
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+KeyBind = NamedTuple("KeyBind", [("bind_name", str), ("mod", int | None)])
+
+
+@dataclass
+class KeyMap:
+    """
+    A dictionary of keybind events with associated keys.
+    """
+
+    key_binds: dict[int | None, list[KeyBind]] = field(default_factory=dict)
+
+    def rebind(self, new_key_bind: KeyBind, new_key: Optional[int] = None) -> None:
+        """
+        Takes the given keybind, unbinds it from its current key, and rebinds
+        it to the given key. If no key is given, it is put under None, meaning
+        the hook is regarded as unbound, and cannot be called.
+
+        :param new_key_bind: Keybind containing the bind name and mod keys.
+        :param new_key: Pygame key id, defaults to None
+        """
+        dead_keys: set[int | None] = set()
+        for key, key_bind_list in self.key_binds.items():
+            binds_to_remove: list[KeyBind] = []
+            key_bind: KeyBind
+            for key_bind in key_bind_list:
+                if key_bind.bind_name == new_key_bind.bind_name:
+                    # Can't directly remove in the loop, could skip one.
+                    binds_to_remove.append(key_bind)
+            removed_bind: KeyBind
+            for removed_bind in binds_to_remove:
+                key_bind_list.remove(removed_bind)
+            if not key_bind_list:
+                dead_keys.add(key)
+        # Clean up any empty lists
+        for key in dead_keys:
+            self.key_binds.pop(key)
+
+        self.key_binds.setdefault(new_key, []).append(new_key_bind)
+
+    def get_bound_key(self, bind_name: str) -> tuple[int | None, int | None] | None:
+        """
+        Finds the current key that binds to the given bind name, and
+        returns it in a tuple with the bound mod keys.
+
+        If the bind is not used, returns None.
+
+        :param bind_name: Name of the bind being used.
+        :return: Tuple containing two ints, first representing the number for
+        a pygame key, the second a bitmask int representing pygame mod keys.
+        """
+        key: int | None
+        key_bind_list: list[KeyBind]
+        key_bind: KeyBind
+        for key, key_bind_list in self.key_binds.items():
+            for key_bind in key_bind_list:
+                if key_bind.bind_name == bind_name:
+                    return key, key_bind.mod
+        return None
+
+    def remove_bind(self, bind_name: str, key: Optional[int] = None) -> None:
+        """
+        Eliminates the specified bind from the specified key, or all instances
+        if no key is specified.
+
+        :param bind_name: Name of the bind being removed
+        :param key: Integer of pygame key code to search, defaults to None
+        """
+        key_bind_list: list[KeyBind] | None
+        if key is not None:
+            key_bind_list = self.key_binds.get(key, None)
+            if not key_bind_list:
+                logger.warning(
+                    f" Cannot remove '{bind_name}';"
+                    f" {pygame.key.name(key)} does not have any binds."
+                )
+                return
+            to_remove: list[KeyBind] = []
+            for key_bind in key_bind_list:
+                if key_bind.bind_name == bind_name:
+                    to_remove.append(key_bind)
+            for item in to_remove:
+                key_bind_list.remove(item)
+            if not to_remove:
+                logger.warning(
+                    f" Cannot remove '{bind_name}';"
+                    f" bind does not exist in {pygame.key.name(key)}"
+                )
+            return
+        for key_bind_list in self.key_binds.values():
+            to_remove = []
+            for key_bind in key_bind_list:
+                if key_bind.bind_name == bind_name:
+                    to_remove.append(key_bind)
+            for item in to_remove:
+                key_bind_list.remove(item)
+        return None
+
+    def pack_binds(self) -> dict:
+        """
+        Packages binds into a serializable dictionary that is more easily saved.
+        """
+        packed_dict: dict[str, list] = {}
+        for key_code, binds in self.key_binds.items():
+            key_name = "null"
+            if key_code:
+                key_name = pygame.key.name(key_code)
+            bind_list = [(bind.bind_name, bind.mod) for bind in binds]
+            packed_dict.update({key_name: bind_list})
+
+        return packed_dict

--- a/src/event_handler/key_map.py
+++ b/src/event_handler/key_map.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 import logging
 from typing import NamedTuple, Optional
@@ -102,6 +103,18 @@ class KeyMap:
             for item in to_remove:
                 key_bind_list.remove(item)
         return None
+
+    def merge(self, other: KeyMap) -> None:
+        """
+        Uses the supplied other map to rebind any existing keys to match the other map.
+        Adds any binds from other map into the current key map, and preserves any other
+        binds it already holds.
+
+        :param other: Key map to be merged.
+        """
+        for key, bind_list in other.key_binds.items():
+            for bind in bind_list:
+                self.rebind(bind, key)
 
     def pack_binds(self) -> dict:
         """

--- a/src/event_handler/key_map.py
+++ b/src/event_handler/key_map.py
@@ -46,16 +46,15 @@ class KeyMap:
 
         self.key_binds.setdefault(new_key, []).append(new_key_bind)
 
-    def get_bound_key(self, bind_name: str) -> tuple[int | None, int | None] | None:
+    def get_bound_key(self, bind_name: str) -> tuple[int | None, int | None]:
         """
         Finds the current key that binds to the given bind name, and
         returns it in a tuple with the bound mod keys.
 
-        If the bind is not used, returns None.
-
         :param bind_name: Name of the bind being used.
         :return: Tuple containing two ints, first representing the number for
         a pygame key, the second a bitmask int representing pygame mod keys.
+        :raises ValueError: Raised if the bind name is not found.
         """
         key: int | None
         key_bind_list: list[KeyBind]
@@ -64,7 +63,7 @@ class KeyMap:
             for key_bind in key_bind_list:
                 if key_bind.bind_name == bind_name:
                     return key, key_bind.mod
-        return None
+        raise ValueError(f"Bind name: {bind_name} not found.")
 
     def remove_bind(self, bind_name: str, key: Optional[int] = None) -> None:
         """

--- a/src/event_handler/key_map.py
+++ b/src/event_handler/key_map.py
@@ -65,6 +65,30 @@ class KeyMap:
                     return key, key_bind.mod
         raise ValueError(f"Bind name: {bind_name} not found.")
 
+    def generate_bind(
+        self,
+        key_bind_name: str,
+        default_key: Optional[int] = None,
+        default_mod: Optional[int] = None,
+    ) -> None:
+        """
+        Looks for a bind matching the given name.
+        Creates the bind if it does not exist.
+        Does not overwrite the key of an existing bind.
+
+        :param key_bind_name: Name assigned to the bind.
+        :param default_key: Pygame key code assigned to a new bind,
+        defaults to None
+        :param default_mod: bitmask of pygame modkeys for a new bind,
+        defaults to pygame.KMOD_NONE
+        """
+        try:
+            self.get_bound_key(key_bind_name)
+        except ValueError:
+            self.key_binds.setdefault(default_key, []).append(
+                KeyBind(bind_name=key_bind_name, mod=default_mod)
+            )
+
     def remove_bind(self, bind_name: str, key: Optional[int] = None) -> None:
         """
         Eliminates the specified bind from the specified key, or all instances

--- a/tests/test_key_manager.py
+++ b/tests/test_key_manager.py
@@ -150,7 +150,7 @@ class TestJSONParser(unittest.TestCase):
 
         packed = keymap.pack_binds()
 
-        unpacked = JSONParser.unpack_binds(packed).key_binds
+        unpacked = JSONParser._unpack_binds(packed)
 
         comp_dict = {
             pygame.K_0: [


### PR DESCRIPTION
Can now save and load keymaps from disk. Currently only supports JSON, but other formats would be easy to implement.

Does not make use of jsonpickle, so there is no vulnerability to pickle attacks.