### PR TITLE
1 sequential flow is impossible

### DIFF
--- a/src/event_handler/base_manager.py
+++ b/src/event_handler/base_manager.py
@@ -67,8 +67,20 @@ class BaseManager(ABC):
 
         return cls
 
+    def notify(self, event: pygame.Event) -> None:
+        """
+        Finds all listeners for a given event, and calls them in a new thread
+
+        :param event: _description_
+        """
+        self.notify_concurrent(event)
+        self.notify_sequential(event)
+
     @abstractmethod
-    def notify(self, event: pygame.Event) -> None: ...
+    def notify_concurrent(self, event: pygame.Event) -> None: ...
+
+    @abstractmethod
+    def notify_sequential(self, event: pygame.Event) -> None: ...
 
     @abstractmethod
     def _add_instance(self, cls: Type[object], instance: object) -> None: ...

--- a/src/event_handler/base_manager.py
+++ b/src/event_handler/base_manager.py
@@ -1,0 +1,31 @@
+from abc import ABC  # , abstractmethod
+from typing import Callable
+
+
+class BaseManager(ABC):
+
+    def sequential(self, func: Callable) -> Callable:
+        """
+        Marks a function as to be run sequentially.
+        Removes a concurrent mark if one exists.
+
+        :param func: The function to be tagger
+        :return: the tagged function
+        """
+        if hasattr(func, "_runs_concurrent"):
+            delattr(func, "_runs_concurrent")
+        setattr(func, "_runs_sequential", True)
+        return func
+
+    def concurrent(self, func: Callable) -> Callable:
+        """
+        Marks a function as to be run concurrently via threading.
+        Removes a sequential mark if one exists.
+
+        :param func: The function to be tagger
+        :return: the tagged function
+        """
+        if hasattr(func, "_runs_sequential"):
+            delattr(func, "_runs_sequential")
+        setattr(func, "_runs_concurrent", True)
+        return func

--- a/src/event_handler/base_manager.py
+++ b/src/event_handler/base_manager.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 import functools
 from typing import Callable, Type
 from weakref import WeakSet
 
 import pygame
+
+
+@dataclass
+class _CallableSets:
+    """
+    A collection of callables, broken up by type
+    """
+
+    concurrent_functions: list[Callable] = field(default_factory=list)
+    concurrent_methods: list[Callable] = field(default_factory=list)
+    sequential_functions: list[Callable] = field(default_factory=list)
+    sequential_methods: list[Callable] = field(default_factory=list)
 
 
 class BaseManager(ABC):
@@ -81,6 +94,16 @@ class BaseManager(ABC):
 
     @abstractmethod
     def notify_sequential(self, event: pygame.Event) -> None: ...
+
+    @abstractmethod
+    def _handle_concurrent(
+        self, event: pygame.Event, callables: _CallableSets
+    ) -> None: ...
+
+    @abstractmethod
+    def _handle_sequential(
+        self, event: pygame.Event, callables: _CallableSets
+    ) -> None: ...
 
     def _add_instance(self, cls: Type[object], instance: object) -> None:
         """

--- a/src/event_handler/base_manager.py
+++ b/src/event_handler/base_manager.py
@@ -20,13 +20,12 @@ class BaseManager(ABC):
     def sequential(self, func: Callable) -> Callable:
         """
         Marks a function as to be run sequentially.
-        Removes a concurrent mark if one exists.
 
-        :param func: The function to be tagger
+        :param func: The function to be tagged
         :return: the tagged function
         """
-        if hasattr(func, "_runs_concurrent"):
-            delattr(func, "_runs_concurrent")
+        # None is smallest data type at 16 bytes
+        # Lowest impact from being attached long term.
         setattr(func, "_runs_sequential", None)
         return func
 
@@ -35,12 +34,11 @@ class BaseManager(ABC):
         Marks a function as to be run concurrently via threading.
         Removes a sequential mark if one exists.
 
-        :param func: The function to be tagger
-        :return: the tagged function
+        :param func: The function to be cleared
+        :return: the cleared function
         """
         if hasattr(func, "_runs_sequential"):
             delattr(func, "_runs_sequential")
-        setattr(func, "_runs_concurrent", None)
         return func
 
     def register_class(self, cls: Type[object]) -> Type[object]:
@@ -71,6 +69,14 @@ class BaseManager(ABC):
 
     @abstractmethod
     def notify(self, event: pygame.Event) -> None: ...
+
+    @abstractmethod
+    def _add_instance(self, cls: Type[object], instance: object) -> None: ...
+
+    @abstractmethod
+    def _capture_method(
+        self, cls: Type[object], method: Callable, tag_data: tuple
+    ) -> None: ...
 
     def _tag_method(self, method: Callable, tag_data: tuple) -> Callable:
         """
@@ -123,14 +129,6 @@ class BaseManager(ABC):
         # from the method.
         for index in reversed(_indexes_to_remove):
             managers.pop(index)
-
-    @abstractmethod
-    def _capture_method(
-        self, cls: Type[object], method: Callable, tag_data: tuple
-    ) -> None: ...
-
-    @abstractmethod
-    def _add_instance(self, cls: Type[object], instance: object) -> None: ...
 
     def _modify_init(self, init: Callable) -> Callable:
         """

--- a/src/event_handler/base_manager.py
+++ b/src/event_handler/base_manager.py
@@ -82,8 +82,14 @@ class BaseManager(ABC):
     @abstractmethod
     def notify_sequential(self, event: pygame.Event) -> None: ...
 
-    @abstractmethod
-    def _add_instance(self, cls: Type[object], instance: object) -> None: ...
+    def _add_instance(self, cls: Type[object], instance: object) -> None:
+        """
+        Adds the instance into the collection of instances
+
+        :param cls: The class of the instance
+        :param instance: The new instance being captured
+        """
+        self._class_listener_instances.setdefault(cls, WeakSet()).add(instance)
 
     @abstractmethod
     def _capture_method(

--- a/src/event_handler/event_manager.py
+++ b/src/event_handler/event_manager.py
@@ -70,16 +70,11 @@ class EventManager(BaseManager):
                     f"{pygame.event.event_name(event_type)}"
                 )
             return
-        event: int
-        for event, event_dict in self._listeners.items():
+        for event_dict in self._listeners.values():
             if not event_dict:
                 continue
             for call_list in event_dict.values():
                 if func in call_list:
-                    logger.info(
-                        f"Removing function '{func.__name__}' from "
-                        f"{pygame.event.event_name(event)}"
-                    )
                     call_list.remove(func)
 
     def _capture_method(self, cls, method, tag_data):

--- a/src/event_handler/event_manager.py
+++ b/src/event_handler/event_manager.py
@@ -100,9 +100,6 @@ class EventManager(BaseManager):
         # -----Add to Assigned Classes-----
         self._assigned_classes.setdefault(cls, []).append(method)
 
-    def _add_instance(self, cls, instance):
-        self._class_listener_instances.setdefault(cls, WeakSet()).add(instance)
-
     def register_method(self, event_type: int) -> Callable:
         """
         Wrapper that marks the method for registration when the class is registered.

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -207,17 +207,9 @@ class KeyListener(BaseManager):
         """
 
         def decorator(method: Callable) -> Callable:
-            # Nearly an exact duplicate of the EventManager version
-            assigned_listeners: list[
-                tuple[KeyListener, str, int | None, int | None, int]
-            ] = []
-            if hasattr(method, "_assigned_listeners"):
-                assigned_listeners = getattr(method, "_assigned_listeners", [])
-            assigned_listeners.append(
-                (self, key_bind_name, default_key, default_mod, event_type)
+            return self._tag_method(
+                method, (key_bind_name, default_key, default_mod, event_type)
             )
-            setattr(method, "_assigned_listeners", assigned_listeners)
-            return method
 
         return decorator
 

--- a/src/event_handler/key_manager.py
+++ b/src/event_handler/key_manager.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-import functools
+import itertools
 import logging
 from pathlib import Path
-import threading
 from typing import Callable, Optional, TextIO, Type
-from weakref import WeakSet
 
 # import file_parser
 from .key_map import KeyBind, KeyMap
+from .base_manager import BaseManager, _CallableSets
 
 import pygame
 
@@ -31,30 +30,27 @@ class FileParser(ABC):
     def _unpack_binds(maps: dict) -> dict: ...
 
 
-class KeyListener:
+class KeyListener(BaseManager):
     _listeners: dict[str, KeyListener] = {}
     key_map: KeyMap = KeyMap()
 
     def __init__(self, handle: str) -> None:
-        self.handle: str = handle
+        super().__init__(handle)
 
         # --------Basic function assignment--------
         # Meta dict, string bind name as key, then event type as key to get callable
-        self._key_hooks: dict[str, dict[int, list[Callable]]] = {}
+        # get(bind_name).get(concurrency).get(event_type)
+        self._key_hooks: dict[str, dict[bool, dict[int, list[Callable]]]] = {}
 
         # --------Class method assignment--------
         # Meta dict, string bind name as key, then Pygame event key, method and
         # affected object as values
+        # get(bind_name).get(concurrency).get(event_type)
         self._class_listeners: dict[
-            str, dict[int, list[tuple[Callable, Type[object]]]]
+            str, dict[bool, dict[int, list[tuple[Callable, Type[object]]]]]
         ] = {}
-        # Registered object as key, instances of object as values
-        # Instances are unique, so make it a set for weak reference
-        self._class_listener_instances: dict[Type[object], WeakSet[object]] = {}
         # Inversion of _class_listeners. Method as key, bind name
         self._class_listener_binds: dict[Callable, list[str]] = {}
-        # Assigned object as key, associated methods as values
-        self._assigned_classes: dict[Type[object], list[Callable]] = {}
 
     def bind(
         self,
@@ -83,9 +79,9 @@ class KeyListener:
 
         def decorator(responder: Callable) -> Callable:
             # Regardless, add the responder to the bind within our hook dict
-            hooks: dict[int, list[Callable]] = self._key_hooks.setdefault(
-                key_bind_name, {}
-            )
+            is_concurrent = not hasattr(responder, "_runs_sequential")
+            event_dict = self._key_hooks.setdefault(key_bind_name, {})
+            hooks = event_dict.setdefault(is_concurrent, {})
             listeners = hooks.setdefault(event_type, [])
             if responder not in listeners:
                 listeners.append(responder)
@@ -132,145 +128,66 @@ class KeyListener:
         None. Defaults to None.
         """
         if bind_name:
-            bind_dict = self._key_hooks.get(bind_name)
-            if not bind_dict:
+            event_dict = self._key_hooks.get(bind_name)
+            if not event_dict:
                 logger.warning(
                     f"Bind name '{bind_name}' does not exist in KeyListener "
                     f"'{self.handle}'"
                 )
                 return
-            for bind in bind_dict.values():
-                if func not in bind:
-                    logger.warning(
-                        f"Cannot remove function {func.__name__} from '"
-                        f"{bind_name}' of KeyListener: {self.handle}.\n"
-                        f"Function is not bound to that name."
-                    )
-                    return
-                bind.remove(func)
-            return
-        for name, bind_dict in self._key_hooks.items():
-            if not bind_dict:
-                continue
-            for bind in bind_dict.values():
-                if bind and func in bind:
-                    logger.info(
-                        f"Removing {func.__name__} from '{name}' in "
-                        f"KeyListener: {self.handle}."
-                    )
+            found = False
+            for bind_dict in event_dict.values():
+                for bind in bind_dict.values():
+                    if func not in bind:
+                        continue
+                    found = True
                     bind.remove(func)
-
-    def register_class(self, cls: Type[object]) -> Type[object]:
-        """
-        Prepares a class for event handling.
-        This will hijack the class's init method to push its instances into
-        the assigned key listener.
-
-        It will also go through and clean up the assigned methods.
-        """
-        cls.__init__ = self._modify_init(cls.__init__)  # type: ignore
-        # Add all of the tagged methods to the callables list
-        logger.debug("Checking for marked methods")
-        for _, method in cls.__dict__.items():
-            if not hasattr(method, "_assigned_listeners"):
-                continue
-
-            logger.debug("Found marked method")
-
-            _assigned_listeners: list[
-                tuple[KeyListener, str, int | None, int | None, int]
-            ] = getattr(method, "_assigned_listeners", [])
-
-            self._verify_listener(cls, method, _assigned_listeners)
-
-            if len(_assigned_listeners) == 0:
-                delattr(method, "_assigned_listeners")
-
-        return cls
-
-    def _verify_listener(
-        self,
-        cls: Type[object],
-        method: Callable,
-        listeners: list[tuple[KeyListener, str, int | None, int | None, int]],
-    ) -> None:
-        """
-        Checks the list of assigned managers for a method and captures it if it is
-        assigned to the calling manager
-
-        :param cls: Class of the object being processed
-        :param method: Callable being registered
-        :param managers: list of managers and pygame events being processed.
-        """
-        _indexes_to_remove: list[int] = []
-        for index, (
-            listener,
-            bind_name,
-            default_key,
-            default_mod,
-            event_type,
-        ) in enumerate(listeners):
-            logger.debug(f"Found assigned manager: {listener}")
-            if listener is not self:
-                continue
-            self._capture_method(
-                cls, method, bind_name, default_key, default_mod, event_type
-            )
-            _indexes_to_remove.append(index)
-            break
-        for index in reversed(_indexes_to_remove):
-            listeners.pop(index)
+            if not found:
+                logger.warning(
+                    f"Cannot remove function {func.__name__} from '"
+                    f"{bind_name}' of KeyListener: {self.handle}.\n"
+                    f"Function is not bound to that name."
+                )
+            return
+        for event_dict in self._key_hooks.values():
+            for bind_dict in event_dict.values():
+                if not bind_dict:
+                    continue
+                for bind in bind_dict.values():
+                    if bind and func in bind:
+                        bind.remove(func)
 
     def _capture_method(
-        self,
-        cls: Type[object],
-        method: Callable,
-        key_bind_name: str,
-        default_key: int | None,
-        default_mod: int | None,
-        event_type: int,
+        self, cls: Type[object], method: Callable, tag_data: tuple
     ) -> None:
         """
         Adds the method, class, and event into the appropriate dictionaries to ensure
         they can be properly notified.
 
         :param cls: Class of the object being processed
-        :param method: Callable being registered
-        :param managers: list of managers and pygame events being processed.
+        :param method: Callable being captured
+        :param tag_data: A tuple containing pertinent registration data
         """
-        logger.debug("Found method assigned to self. Registering.")
-        logger.debug(f"Registering {method} to {pygame.event.event_name(event_type)}")
+        is_concurrent = not hasattr(method, "_runs_sequential")
+        key_bind_name: str = tag_data[0]
+        default_key: int = tag_data[1]
+        default_mod: int = tag_data[2]
+        event_type: int = tag_data[3]
 
         self.key_map.generate_bind(key_bind_name, default_key, default_mod)
 
-        self._class_listeners.setdefault(key_bind_name, {}).setdefault(
-            event_type, []
-        ).append((method, cls))
+        # -----Add to Class Listeners-----
+        event_dict = self._class_listeners.setdefault(key_bind_name, {})
+        concurrency_dict = event_dict.setdefault(is_concurrent, {})
+        listeners = concurrency_dict.setdefault(event_type, [])
+        listeners.append((method, cls))
+
+        # -----Add to Class Listener Events-----
+
         self._class_listener_binds.setdefault(method, []).append(key_bind_name)
+
+        # -----Add to Assigned Classes-----
         self._assigned_classes.setdefault(cls, []).append(method)
-
-    def _modify_init(self, init: Callable) -> Callable:
-        """
-        Extracts the class and instance being generated, and puts them into a
-        dict, so that the method can be called upon it
-
-        :param init: The initializer function of a class being registered.
-        :return: The modified init function
-        """
-        functools.wraps(init)  # Needs this
-
-        def wrapper(*args, **kwds):
-            # args[0] of a non-class, non-static method is the instance
-            # This is called whenever the class is instantiated,
-            # and the instance is extracted and can be stored
-            instance = args[0]
-            cls = instance.__class__
-            # No need to check for the instance, each only calls this once
-            self._class_listener_instances.setdefault(cls, WeakSet()).add(instance)
-            logger.debug(f"Extracted instance {instance} from {cls}")
-            return init(*args, **kwds)
-
-        return wrapper
 
     def bind_method(
         self,
@@ -324,18 +241,19 @@ class KeyListener:
         :param method: Method being unbound
         """
         for bind_name in self._class_listener_binds.get(method, []):
-            event_sets = self._class_listeners.get(bind_name, {})
-            for event_type, listener_sets in event_sets.items():
-                # We don't know the event type for the method,
-                # so we need to check all of them
-                listener_sets = list(
-                    filter(
-                        lambda listener_set: method is not listener_set[0],
-                        listener_sets,
+            concurrency_dict = self._class_listeners.get(bind_name, {})
+            for concurrency, event_dict in concurrency_dict.items():
+                for event_type, listener_sets in event_dict.items():
+                    # Retain only the listeners that are not the method
+                    listener_sets = list(
+                        filter(
+                            lambda listener_set: method is not listener_set[0],
+                            listener_sets,
+                        )
                     )
-                )
-                event_sets.update({event_type: listener_sets})
-            self._class_listeners.update({bind_name: event_sets})
+                    event_dict.update({event_type: listener_sets})
+                concurrency_dict.update({concurrency: event_dict})
+            self._class_listeners.update({bind_name: concurrency_dict})
         self._class_listener_binds.pop(method)
 
     def clear_bind(self, bind_name: str, eliminate_bind: bool = False) -> None:
@@ -366,35 +284,60 @@ class KeyListener:
             logger.info(f"Clearing all methods from bind {bind_name}")
             class_call_list.clear()
 
-    def notify(self, event: pygame.Event) -> None:
+    def _validate_input(self, key_bind: KeyBind, input_data: tuple) -> bool:
+        """
+        Validates the input data against a key bind to ensure a match
+
+        :param key_bind: Target key bind containing desired input data
+        :param input_data: Data coming from the recent input event
+        :return: True if the input data matches the bind, otherwise false
+        """
+        is_valid = False
+        # This structure is here to potentially leave room for
+        key_changed: int | None = input_data[0]
+        mod_keys: int | None = input_data[1]
+        if key_changed is not None:
+            mod = key_bind.mod
+            if mod is None:
+                is_valid = True
+            elif mod_keys is not None and (mod & mod_keys or mod is mod_keys):
+                # mod is mod_keys catches pygame.KMOD_NONE
+                is_valid = True
+        return is_valid
+
+    def _get_callables(self, event: pygame.Event) -> _CallableSets:
         """
         Calls all registered functions and methods that make use of the given event
+
+        TODO Seperate into notify_concurrent and notify_sequential
 
         :param event: pygame event to be passed to the callables
         """
         key_changed: int | None = getattr(event, "key", None)
         mod_keys: int | None = getattr(event, "mod", None)
+        input_data = (key_changed, mod_keys)
         key_binds = self.key_map.key_binds.get(key_changed, [])
+        conc_funcs_lists = []
+        seq_funcs_lists = []
+        conc_methods_lists = []
+        seq_methods_lists = []
         for key_bind in key_binds:
             # Try to match the mod keys. If they don't, move on to the next.
-            if not (
-                (key_bind.mod is None)
-                or (mod_keys is not None and (key_bind.mod & mod_keys))
-            ):
+            if not self._validate_input(key_bind, input_data):
                 continue
             hooks = self._key_hooks.get(key_bind.bind_name, {})
-            # Pass along our event to each callable.
-            responders = hooks.get(event.type, [])
-            for responder in responders:
-                threading.Thread(target=responder, args=(event,)).start()
-                # hook(event)
+            conc_funcs_lists.append(hooks.get(True, {}).get(event.type, []))
+            seq_funcs_lists.append(hooks.get(False, {}).get(event.type, []))
 
             method_hooks = self._class_listeners.get(key_bind.bind_name, {})
-            listeners = method_hooks.get(event.type, [])
-            for method, cls in listeners:
-                instances = self._class_listener_instances.get(cls, WeakSet())
-                for instance in instances:
-                    threading.Thread(target=method, args=(instance, event)).start()
+            conc_methods_lists.append(method_hooks.get(True, {}).get(event.type, []))
+            seq_methods_lists.append(method_hooks.get(False, {}).get(event.type, []))
+        return _CallableSets(
+            concurrent_functions=list(itertools.chain(*conc_funcs_lists)),
+            sequential_functions=list(itertools.chain(*seq_funcs_lists)),
+            concurrent_methods=list(itertools.chain(*conc_methods_lists)),
+            sequential_methods=list(itertools.chain(*seq_methods_lists)),
+        )
 
     @classmethod
     def load_from_file(cls, file_path: Path, parser: Type[FileParser]) -> None:


### PR DESCRIPTION
Adds the ability to process functions and methods as part of sequential flow, reducing risks of race conditions. This feature is more viable for simpler games, as looping over a large set of sequential processes can take some time, and can drag down the game loop.

Thread delaying measures like time.sleep() should not be used in sequential functions and methods.

Sequential functions and methods are started after concurrent ones. This allows the concurrent ones to start running independently, since the sequential functions and methods can take a long time to complete.